### PR TITLE
Update API for Nutch 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ shortened link (t.co/...) and the original link. We want to insert this
 relation into the crawl DB to capture the relation between the two URLs and
 to avoid re-crawling the same URL.
 
+Version compatibility
+---------------------
+
+Only Nutch 2.x is supported. Version `0.1` is compatible with Nutch versions <= 2.2.1. Version `0.2` supports Nutch >= 2.3.
 
 Usage
 -----
@@ -23,7 +27,7 @@ Include the module through Maven:
 	  <dependency>
 	    <groupId>de.l3s.icrawl</groupId>
 	    <artifactId>nutch-injector</artifactId>
-	    <version>0.1</version>
+	    <version>0.2</version>
 	  </dependency>
 	</dependencies>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.l3s.icrawl</groupId>
   <artifactId>nutch-injector</artifactId>
-  <version>0.3</version>
+  <version>0.4-SNAPSHOT</version>
   <name>Nutch URL Injector</name>
   <description>Adds seed URLs and redirect entries directly to a Nutch 2.x crawl DB</description>
   <url>https://github.com/L3S/nutch-injector</url>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <developerConnection>scm:git:https://github.com/L3S/nutch-injector</developerConnection>
   </scm>
   <properties>
-    <nutch.version>2.3-SNAPSHOT</nutch.version>
+    <nutch.version>2.3-icrawl-1617937</nutch.version>
     <hadoop.version>1.2.0</hadoop.version>
     <gora.version>0.4</gora.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
     <developerConnection>scm:git:https://github.com/L3S/nutch-injector</developerConnection>
   </scm>
   <properties>
-    <nutch.version>2.2.1</nutch.version>
+    <nutch.version>2.3-SNAPSHOT</nutch.version>
     <hadoop.version>1.2.0</hadoop.version>
-    <gora.version>0.3</gora.version>
+    <gora.version>0.4</gora.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.6</java.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <nutch.version>2.3-icrawl-1617937</nutch.version>
     <hadoop.version>1.2.0</hadoop.version>
-    <gora.version>0.4</gora.version>
+    <gora.version>0.5</gora.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.6</java.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -83,11 +83,11 @@
   <distributionManagement>
     <repository>
       <id>icrawl-releases</id>
-      <url>http://maven.l3s.uni-hannover.de:8088/nexus/content/repositories/icrawl_release/</url>
+      <url>http://maven.l3s.uni-hannover.de:9088/nexus/content/repositories/icrawl_release/</url>
     </repository>
     <snapshotRepository>
       <id>icrawl-snapshots</id>
-      <url>http://maven.l3s.uni-hannover.de:8088/nexus/content/repositories/icrawl_snapshots/</url>
+      <url>http://maven.l3s.uni-hannover.de:9088/nexus/content/repositories/icrawl_snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.l3s.icrawl</groupId>
   <artifactId>nutch-injector</artifactId>
-  <version>0.3-SNAPSHOT</version>
+  <version>0.3</version>
   <name>Nutch URL Injector</name>
   <description>Adds seed URLs and redirect entries directly to a Nutch 2.x crawl DB</description>
   <url>https://github.com/L3S/nutch-injector</url>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.l3s.icrawl</groupId>
   <artifactId>nutch-injector</artifactId>
-  <version>0.2-SNAPSHOT</version>
+  <version>0.3-SNAPSHOT</version>
   <name>Nutch URL Injector</name>
   <description>Adds seed URLs and redirect entries directly to a Nutch 2.x crawl DB</description>
   <url>https://github.com/L3S/nutch-injector</url>

--- a/src/main/java/de/l3s/icrawl/nutch/Injector.java
+++ b/src/main/java/de/l3s/icrawl/nutch/Injector.java
@@ -80,6 +80,7 @@ public class Injector implements Closeable {
     public Injector(Configuration conf, DataStore<String, WebPage> store)
             throws InjectorSetupException {
         this.store = store;
+        store.createSchema();
         defaultScore = conf.getFloat("db.score.injected", 1.0f);
         defaultInterval = conf.getInt("db.fetch.interval.default", 2592000);
     }

--- a/src/main/java/de/l3s/icrawl/nutch/Injector.java
+++ b/src/main/java/de/l3s/icrawl/nutch/Injector.java
@@ -317,6 +317,7 @@ public class Injector implements Closeable {
         page.getMarkers().put(DbUpdaterJob.DISTANCE, ZERO_STRING);
 
         page.getMarkers().put(Mark.FETCH_MARK.name(), batchId);
+        Mark.FETCH_MARK.putMark(page, batchId);
 
         putRow(url, page, true);
         return true;

--- a/src/main/java/de/l3s/icrawl/nutch/Injector.java
+++ b/src/main/java/de/l3s/icrawl/nutch/Injector.java
@@ -296,6 +296,7 @@ public class Injector implements Closeable {
             return false;
         }
         WebPage page = WebPage.newBuilder().build();
+        page.setReprUrl(new Utf8(url));
         page.setStatus((int) CrawlStatus.STATUS_FETCHED);
         page.setFetchTime(System.currentTimeMillis());
 

--- a/src/main/java/de/l3s/icrawl/nutch/Injector.java
+++ b/src/main/java/de/l3s/icrawl/nutch/Injector.java
@@ -215,7 +215,7 @@ public class Injector implements Closeable {
 
     /** Create WebPage object for redirecting URL. */
     private WebPage createRedirectWebPage(String from, String to, Map<String, String> metadata) {
-        WebPage page = new WebPage();
+        WebPage page = WebPage.newBuilder().build();
         page.getOutlinks().put(new Utf8(to), new Utf8());
         page.getMetadata().put(FetcherJob.REDIRECT_DISCOVERED, TableUtil.YES_VAL);
         page.setReprUrl(new Utf8(to));
@@ -227,7 +227,7 @@ public class Injector implements Closeable {
 
     /** Create WebPage object for a seed URL. */
     private WebPage createSeedWebPage(String url, Map<String, String> metadata) {
-        WebPage webPage = new WebPage();
+        WebPage webPage = WebPage.newBuilder().build();
         float score = defaultScore;
         int interval = defaultInterval;
         for (Map.Entry<String, String> entry : metadata.entrySet()) {
@@ -255,7 +255,7 @@ public class Injector implements Closeable {
         webPage.setFetchInterval(interval);
         webPage.setFetchTime(System.currentTimeMillis());
         webPage.getMarkers().put(DbUpdaterJob.DISTANCE, ZERO_STRING);
-        Mark.INJECT_MARK.putMark(webPage, YES_STRING);
+        webPage.getMarkers().put(Mark.INJECT_MARK.name(), YES_STRING);
         return webPage;
     }
 
@@ -295,7 +295,7 @@ public class Injector implements Closeable {
         if (hasUrl(url)) {
             return false;
         }
-        WebPage page = new WebPage();
+        WebPage page = WebPage.newBuilder().build();
         page.setStatus((int) CrawlStatus.STATUS_FETCHED);
         page.setFetchTime(System.currentTimeMillis());
 
@@ -315,7 +315,7 @@ public class Injector implements Closeable {
 
         page.getMarkers().put(DbUpdaterJob.DISTANCE, ZERO_STRING);
 
-        Mark.FETCH_MARK.putMark(page, batchId);
+        page.getMarkers().put(Mark.FETCH_MARK.name(), batchId);
 
         putRow(url, page, true);
         return true;

--- a/src/main/java/de/l3s/icrawl/nutch/Injector.java
+++ b/src/main/java/de/l3s/icrawl/nutch/Injector.java
@@ -216,12 +216,12 @@ public class Injector implements Closeable {
     /** Create WebPage object for redirecting URL. */
     private WebPage createRedirectWebPage(String from, String to, Map<String, String> metadata) {
         WebPage page = new WebPage();
-        page.putToOutlinks(new Utf8(to), new Utf8());
-        page.putToMetadata(FetcherJob.REDIRECT_DISCOVERED, TableUtil.YES_VAL);
+        page.getOutlinks().put(new Utf8(to), new Utf8());
+        page.getMetadata().put(FetcherJob.REDIRECT_DISCOVERED, TableUtil.YES_VAL);
         page.setReprUrl(new Utf8(to));
         page.setFetchTime(System.currentTimeMillis());
         page.setProtocolStatus(ProtocolStatusUtils.makeStatus(ProtocolStatusCodes.MOVED, to));
-        page.setStatus(CrawlStatus.STATUS_REDIR_PERM);
+        page.setStatus((int) CrawlStatus.STATUS_REDIR_PERM);
         return page;
     }
 
@@ -249,12 +249,12 @@ public class Injector implements Closeable {
             }
             Utf8 writtenKey = new Utf8(key);
             ByteBuffer writtenValue = ByteBuffer.wrap(value.getBytes(UTF_8));
-            webPage.putToMetadata(writtenKey, writtenValue);
+            webPage.getMetadata().put(writtenKey, writtenValue);
         }
         webPage.setScore(score);
         webPage.setFetchInterval(interval);
         webPage.setFetchTime(System.currentTimeMillis());
-        webPage.putToMarkers(DbUpdaterJob.DISTANCE, ZERO_STRING);
+        webPage.getMarkers().put(DbUpdaterJob.DISTANCE, ZERO_STRING);
         Mark.INJECT_MARK.putMark(webPage, YES_STRING);
         return webPage;
     }
@@ -296,7 +296,7 @@ public class Injector implements Closeable {
             return false;
         }
         WebPage page = new WebPage();
-        page.setStatus(CrawlStatus.STATUS_FETCHED);
+        page.setStatus((int) CrawlStatus.STATUS_FETCHED);
         page.setFetchTime(System.currentTimeMillis());
 
         if (content != null) {
@@ -309,11 +309,11 @@ public class Injector implements Closeable {
             for (Map.Entry<String, String> entry : metadata.entrySet()) {
                 Utf8 key = new Utf8(entry.getKey());
                 ByteBuffer value = ByteBuffer.wrap(entry.getValue().getBytes(UTF_8));
-                page.putToMetadata(key, value);
+                page.getMetadata().put(key, value);
             }
         }
 
-        page.putToMarkers(DbUpdaterJob.DISTANCE, ZERO_STRING);
+        page.getMarkers().put(DbUpdaterJob.DISTANCE, ZERO_STRING);
 
         Mark.FETCH_MARK.putMark(page, batchId);
 

--- a/src/test/java/de/l3s/icrawl/nutch/InjectorTest.java
+++ b/src/test/java/de/l3s/icrawl/nutch/InjectorTest.java
@@ -6,12 +6,14 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.nutch.storage.WebPage;
 import org.apache.nutch.util.TableUtil;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
+@Ignore
 public class InjectorTest {
 
     private static final String SHORT_URL = "http://t.co/ZNyOoEwAwN";

--- a/src/test/java/de/l3s/icrawl/nutch/InjectorTest.java
+++ b/src/test/java/de/l3s/icrawl/nutch/InjectorTest.java
@@ -35,7 +35,7 @@ public class InjectorTest {
 
     @Test
     public void testHasUrl_true() throws Exception {
-        store.put(TableUtil.reverseUrl(URL), new WebPage());
+        store.put(TableUtil.reverseUrl(URL), WebPage.newBuilder().build());
         boolean hasUrl = injector.hasUrl(URL);
         assertTrue("has URL", hasUrl);
     }


### PR DESCRIPTION
Nutch 2.3 has updated its Gora dependency to 0.4, which caused some incompatible API changes for the stored objects. We can merge this when Nutch 2.3 is released.
